### PR TITLE
Permit any Mapping as source of DataFrame

### DIFF
--- a/pandas/core/apply.py
+++ b/pandas/core/apply.py
@@ -664,7 +664,7 @@ class Apply(metaclass=abc.ABCMeta):
             # people may aggregate on a non-callable attribute
             # but don't let them think they can pass args to it
             assert len(args) == 0
-            assert len([kwarg for kwarg in kwargs if kwarg not in ["axis"]]) == 0
+            assert not any(kwarg == "axis" for kwarg in kwargs)
             return f
         elif hasattr(np, func) and hasattr(obj, "__array__"):
             # in particular exclude Window

--- a/pandas/core/computation/eval.py
+++ b/pandas/core/computation/eval.py
@@ -193,6 +193,8 @@ def eval(
     corresponding bitwise operators.  :class:`~pandas.Series` and
     :class:`~pandas.DataFrame` objects are supported and behave as they would
     with plain ol' Python evaluation.
+    `eval` can run arbitrary code which can make you vulnerable to code
+    injection if you pass user input to this function.
 
     Parameters
     ----------

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -739,7 +739,7 @@ class DataFrame(NDFrame, OpsMixin):
             raise ValueError("columns cannot be a set")
 
         if copy is None:
-            if isinstance(data, dict):
+            if isinstance(data, Mapping):
                 # retain pre-GH#38939 default behavior
                 copy = True
             elif not isinstance(data, (Index, DataFrame, Series)):
@@ -758,7 +758,7 @@ class DataFrame(NDFrame, OpsMixin):
                 data, axes={"index": index, "columns": columns}, dtype=dtype, copy=copy
             )
 
-        elif isinstance(data, dict):
+        elif isinstance(data, Mapping):
             # GH#38939 de facto copy defaults to False only in non-dict cases
             mgr = dict_to_mgr(data, index, columns, dtype=dtype, copy=copy)
         elif isinstance(data, ma.MaskedArray):

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4472,6 +4472,9 @@ class DataFrame(NDFrame, OpsMixin):
         """
         Query the columns of a DataFrame with a boolean expression.
 
+        This method can run arbitrary code which can make you vulnerable to code
+        injection if you pass user input to this function.
+
         Parameters
         ----------
         expr : str

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1750,11 +1750,15 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             if `key` matches multiple labels
         """
         axis = self._get_axis_number(axis)
-        other_axes = [ax for ax in range(self._AXIS_LEN) if ax != axis]
+        first_other_axes = next(
+            (ax for ax in range(self._AXIS_LEN) if ax != axis), None
+        )
 
         if self._is_label_reference(key, axis=axis):
             self._check_label_or_level_ambiguity(key, axis=axis)
-            values = self.xs(key, axis=other_axes[0])._values
+            if first_other_axes is None:
+                raise ValueError("axis matched all axes")
+            values = self.xs(key, axis=first_other_axes)._values
         elif self._is_level_reference(key, axis=axis):
             values = self.axes[axis].get_level_values(key)._values
         else:
@@ -1762,7 +1766,9 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
 
         # Check for duplicates
         if values.ndim > 1:
-            if other_axes and isinstance(self._get_axis(other_axes[0]), MultiIndex):
+            if first_other_axes is not None and isinstance(
+                self._get_axis(first_other_axes), MultiIndex
+            ):
                 multi_message = (
                     "\n"
                     "For a multi-index, the label must be a "

--- a/pandas/core/internals/construction.py
+++ b/pandas/core/internals/construction.py
@@ -347,7 +347,7 @@ def _check_values_indices_shape_match(
 
 
 def dict_to_mgr(
-    data: dict,
+    data: Mapping,
     index,
     columns,
     *,

--- a/pandas/io/excel/_base.py
+++ b/pandas/io/excel/_base.py
@@ -857,24 +857,23 @@ class BaseExcelReader(Generic[_WorkbookT]):
         # a row containing just the index name(s)
         has_index_names = False
         if is_list_header and not is_len_one_list_header and index_col is not None:
-            index_col_list: Sequence[int]
+            index_col_set: set[int]
             if isinstance(index_col, int):
-                index_col_list = [index_col]
+                index_col_set = {index_col}
             else:
                 assert isinstance(index_col, Sequence)
-                index_col_list = index_col
+                index_col_set = set(index_col)
 
             # We have to handle mi without names. If any of the entries in the data
             # columns are not empty, this is a regular row
             assert isinstance(header, Sequence)
             if len(header) < len(data):
                 potential_index_names = data[len(header)]
-                potential_data = [
-                    x
+                has_index_names = all(
+                    x == "" or x is None
                     for i, x in enumerate(potential_index_names)
-                    if not control_row[i] and i not in index_col_list
-                ]
-                has_index_names = all(x == "" or x is None for x in potential_data)
+                    if not control_row[i] and i not in index_col_set
+                )
 
         if is_list_like(index_col):
             # Forward fill values for MultiIndex index.
@@ -1457,9 +1456,9 @@ def inspect_excel_format(
         with zipfile.ZipFile(stream) as zf:
             # Workaround for some third party files that use forward slashes and
             # lower case names.
-            component_names = [
+            component_names = {
                 name.replace("\\", "/").lower() for name in zf.namelist()
-            ]
+            }
 
         if "xl/workbook.xml" in component_names:
             return "xlsx"

--- a/pandas/io/excel/_odfreader.py
+++ b/pandas/io/excel/_odfreader.py
@@ -122,29 +122,25 @@ class ODFReader(BaseExcelReader["OpenDocument"]):
         table: list[list[Scalar | NaTType]] = []
 
         for sheet_row in sheet_rows:
-            sheet_cells = [
-                x
-                for x in sheet_row.childNodes
-                if hasattr(x, "qname") and x.qname in cell_names
-            ]
             empty_cells = 0
             table_row: list[Scalar | NaTType] = []
 
-            for sheet_cell in sheet_cells:
-                if sheet_cell.qname == table_cell_name:
-                    value = self._get_cell_value(sheet_cell)
-                else:
-                    value = self.empty_value
+            for sheet_cell in sheet_row.childNodes:
+                if hasattr(sheet_cell, "qname") and sheet_cell.qname in cell_names:
+                    if sheet_cell.qname == table_cell_name:
+                        value = self._get_cell_value(sheet_cell)
+                    else:
+                        value = self.empty_value
 
-                column_repeat = self._get_column_repeat(sheet_cell)
+                    column_repeat = self._get_column_repeat(sheet_cell)
 
-                # Queue up empty values, writing only if content succeeds them
-                if value == self.empty_value:
-                    empty_cells += column_repeat
-                else:
-                    table_row.extend([self.empty_value] * empty_cells)
-                    empty_cells = 0
-                    table_row.extend([value] * column_repeat)
+                    # Queue up empty values, writing only if content succeeds them
+                    if value == self.empty_value:
+                        empty_cells += column_repeat
+                    else:
+                        table_row.extend([self.empty_value] * empty_cells)
+                        empty_cells = 0
+                        table_row.extend([value] * column_repeat)
 
             if max_row_len < len(table_row):
                 max_row_len = len(table_row)

--- a/pandas/io/excel/_xlrd.py
+++ b/pandas/io/excel/_xlrd.py
@@ -128,16 +128,13 @@ class XlrdReader(BaseExcelReader["Book"]):
                         cell_contents = val
             return cell_contents
 
-        data = []
-
         nrows = sheet.nrows
         if file_rows_needed is not None:
             nrows = min(nrows, file_rows_needed)
-        for i in range(nrows):
-            row = [
+        return [
+            [
                 _parse_cell(value, typ)
                 for value, typ in zip(sheet.row_values(i), sheet.row_types(i))
             ]
-            data.append(row)
-
-        return data
+            for i in range(nrows)
+        ]

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -157,6 +157,7 @@ def _convert_arrays_to_dataframe(
     dtype_backend: DtypeBackend | Literal["numpy"] = "numpy",
 ) -> DataFrame:
     content = lib.to_object_array_tuples(data)
+    idx_len = content.shape[0]
     arrays = convert_object_array(
         list(content.T),
         dtype=None,
@@ -177,9 +178,9 @@ def _convert_arrays_to_dataframe(
             result_arrays.append(ArrowExtensionArray(pa_array))
         arrays = result_arrays  # type: ignore[assignment]
     if arrays:
-        df = DataFrame(dict(zip(range(len(columns)), arrays)))
-        df.columns = columns
-        return df
+        return DataFrame._from_arrays(
+            arrays, columns=columns, index=range(idx_len), verify_integrity=False
+        )
     else:
         return DataFrame(columns=columns)
 

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -8,6 +8,7 @@ from collections import (
 from collections.abc import (
     Iterator,
     Mapping,
+    Sequence,
 )
 from dataclasses import make_dataclass
 from datetime import (
@@ -92,6 +93,19 @@ class DictWrapper(Mapping):
 
     def __len__(self):
         return self._dict.__len__()
+
+
+class ListWrapper(Sequence):
+    _list: list
+
+    def __init__(self, lst: list) -> None:
+        self._list = lst
+
+    def __getitem__(self, i):
+        return self._list[i]
+
+    def __len__(self):
+        return self._list.__len__()
 
 
 class TestDataFrameConstructors:
@@ -2926,6 +2940,36 @@ class TestDataFrameConstructorWithDatetimeTZ:
 
         # construction
         df = DataFrame(DictWrapper({"A": idx, "B": dr}))
+        assert df["A"].dtype, "M8[ns, US/Eastern"
+        assert df["A"].name == "A"
+        tm.assert_series_equal(df["A"], Series(idx, name="A"))
+        tm.assert_series_equal(df["B"], Series(dr, name="B"))
+
+    def test_from_mappiog_list(self):
+        idx = Index(date_range("20130101", periods=3, tz="US/Eastern"), name="foo")
+        dr = date_range("20130110", periods=3)
+        data = DataFrame({"A": idx, "B": dr})
+        mapping_list = [
+            DictWrapper(record) for record in data.to_dict(orient="records")
+        ]
+
+        # construction
+        df = DataFrame(mapping_list)
+        assert df["A"].dtype, "M8[ns, US/Eastern"
+        assert df["A"].name == "A"
+        tm.assert_series_equal(df["A"], Series(idx, name="A"))
+        tm.assert_series_equal(df["B"], Series(dr, name="B"))
+
+    def test_from_mappiog_sequence(self):
+        idx = Index(date_range("20130101", periods=3, tz="US/Eastern"), name="foo")
+        dr = date_range("20130110", periods=3)
+        data = DataFrame({"A": idx, "B": dr})
+        mapping_list = ListWrapper(
+            [DictWrapper(record) for record in data.to_dict(orient="records")]
+        )
+
+        # construction
+        df = DataFrame(mapping_list)
         assert df["A"].dtype, "M8[ns, US/Eastern"
         assert df["A"].name == "A"
         tm.assert_series_equal(df["A"], Series(idx, name="A"))

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -5,7 +5,10 @@ from collections import (
     defaultdict,
     namedtuple,
 )
-from collections.abc import Iterator
+from collections.abc import (
+    Iterator,
+    Mapping,
+)
 from dataclasses import make_dataclass
 from datetime import (
     date,
@@ -73,6 +76,22 @@ MIXED_INT_DTYPES = [
     "int32",
     "int64",
 ]
+
+
+class DictWrapper(Mapping):
+    _dict: dict
+
+    def __init__(self, d: dict) -> None:
+        self._dict = d
+
+    def __getitem__(self, key):
+        return self._dict[key]
+
+    def __iter__(self):
+        return self._dict.__iter__()
+
+    def __len__(self):
+        return self._dict.__len__()
 
 
 class TestDataFrameConstructors:
@@ -2896,6 +2915,17 @@ class TestDataFrameConstructorWithDatetimeTZ:
 
         # construction
         df = DataFrame({"A": idx, "B": dr})
+        assert df["A"].dtype, "M8[ns, US/Eastern"
+        assert df["A"].name == "A"
+        tm.assert_series_equal(df["A"], Series(idx, name="A"))
+        tm.assert_series_equal(df["B"], Series(dr, name="B"))
+
+    def test_from_dict_with_mapping(self):
+        idx = Index(date_range("20130101", periods=3, tz="US/Eastern"), name="foo")
+        dr = date_range("20130110", periods=3)
+
+        # construction
+        df = DataFrame(DictWrapper({"A": idx, "B": dr}))
         assert df["A"].dtype, "M8[ns, US/Eastern"
         assert df["A"].name == "A"
         tm.assert_series_equal(df["A"], Series(idx, name="A"))


### PR DESCRIPTION
This is a proof-of-concept patch to accept a `Mapping` to create a `DataFrame`.
Applying this change makes `pd.DataFrame(Dict("a" => [1, 2, 3], "b" => [4, 5, 6]))` in Julia work.

```
julia> df = pd.DataFrame(Dict("a" => [1, 2, 3], "b" => [4, 5, 6]))
Python:
   b  a
0  4  1
1  5  2
2  6  3
```

There is no performance degradation.

```
$ asv continuous -E virtualenv -b ^frame_ctor.FromDict origin/main HEAD
· Creating environments
· Discovering benchmarks
·· Uninstalling from virtualenv-py3.10-Cython3.0-jinja2-matplotlib-meson-meson-python-numba-numexpr-odfpy-openpyxl-pyarrow-python-build-scipy-sqlalchemy-tables-xlrd-xlsxwriter
·· Installing 684a22fb <support_mapping_in_dataframe> into virtualenv-py3.10-Cython3.0-jinja2-matplotlib-meson-meson-python-numba-numexpr-odfpy-openpyxl-pyarrow-python-build-scipy-sqlalchemy-tables-xlrd-xlsxwriter..
· Running 16 total benchmarks (2 commits * 1 environments * 8 benchmarks)
[ 0.00%] · For pandas commit 2aa155ae <main> (round 1/2):
[ 0.00%] ·· Building for virtualenv-py3.10-Cython3.0-jinja2-matplotlib-meson-meson-python-numba-numexpr-odfpy-openpyxl-pyarrow-python-build-scipy-sqlalchemy-tables-xlrd-xlsxwriter..
[ 0.00%] ·· Benchmarking virtualenv-py3.10-Cython3.0-jinja2-matplotlib-meson-meson-python-numba-numexpr-odfpy-openpyxl-pyarrow-python-build-scipy-sqlalchemy-tables-xlrd-xlsxwriter
[ 3.12%] ··· Running (frame_ctor.FromDicts.time_dict_of_categoricals--)........
[25.00%] · For pandas commit 684a22fb <support_mapping_in_dataframe> (round 1/2):
[25.00%] ·· Building for virtualenv-py3.10-Cython3.0-jinja2-matplotlib-meson-meson-python-numba-numexpr-odfpy-openpyxl-pyarrow-python-build-scipy-sqlalchemy-tables-xlrd-xlsxwriter..
[25.00%] ·· Benchmarking virtualenv-py3.10-Cython3.0-jinja2-matplotlib-meson-meson-python-numba-numexpr-odfpy-openpyxl-pyarrow-python-build-scipy-sqlalchemy-tables-xlrd-xlsxwriter
[28.12%] ··· Running (frame_ctor.FromDicts.time_dict_of_categoricals--)........
[50.00%] · For pandas commit 684a22fb <support_mapping_in_dataframe> (round 2/2):
[50.00%] ·· Benchmarking virtualenv-py3.10-Cython3.0-jinja2-matplotlib-meson-meson-python-numba-numexpr-odfpy-openpyxl-pyarrow-python-build-scipy-sqlalchemy-tables-xlrd-xlsxwriter
[53.12%] ··· frame_ctor.FromDicts.time_dict_of_categoricals                                327±8μs
[56.25%] ··· frame_ctor.FromDicts.time_list_of_dict                                    16.8±0.09ms
[59.38%] ··· frame_ctor.FromDicts.time_nested_dict                                      16.1±0.2ms
[62.50%] ··· frame_ctor.FromDicts.time_nested_dict_columns                              16.3±0.3ms
[65.62%] ··· frame_ctor.FromDicts.time_nested_dict_index                                13.2±0.1ms
[68.75%] ··· frame_ctor.FromDicts.time_nested_dict_index_columns                       12.9±0.08ms
[71.88%] ··· frame_ctor.FromDicts.time_nested_dict_int64                                29.1±0.1ms
[75.00%] ··· frame_ctor.FromDictwithTimestamp.time_dict_with_timestamp_offsets                  ok
[75.00%] ··· ======== ============
              offset
             -------- ------------
              <Nano>   7.97±0.1ms
              <Hour>   10.9±0.2ms
             ======== ============

[75.00%] · For pandas commit 2aa155ae <main> (round 2/2):
[75.00%] ·· Building for virtualenv-py3.10-Cython3.0-jinja2-matplotlib-meson-meson-python-numba-numexpr-odfpy-openpyxl-pyarrow-python-build-scipy-sqlalchemy-tables-xlrd-xlsxwriter..
[75.00%] ·· Benchmarking virtualenv-py3.10-Cython3.0-jinja2-matplotlib-meson-meson-python-numba-numexpr-odfpy-openpyxl-pyarrow-python-build-scipy-sqlalchemy-tables-xlrd-xlsxwriter
[78.12%] ··· frame_ctor.FromDicts.time_dict_of_categoricals                                330±2μs
[81.25%] ··· frame_ctor.FromDicts.time_list_of_dict                                     17.2±0.3ms
[84.38%] ··· frame_ctor.FromDicts.time_nested_dict                                     16.2±0.08ms
[87.50%] ··· frame_ctor.FromDicts.time_nested_dict_columns                              16.2±0.1ms
[90.62%] ··· frame_ctor.FromDicts.time_nested_dict_index                                13.2±0.2ms
[93.75%] ··· frame_ctor.FromDicts.time_nested_dict_index_columns                        13.5±0.2ms
[96.88%] ··· frame_ctor.FromDicts.time_nested_dict_int64                                29.7±0.3ms
[100.00%] ··· frame_ctor.FromDictwithTimestamp.time_dict_with_timestamp_offsets                  ok
[100.00%] ··· ======== =============
               offset
              -------- -------------
               <Nano>   8.16±0.07ms
               <Hour>   11.2±0.06ms
              ======== =============


BENCHMARKS NOT SIGNIFICANTLY CHANGED.
```